### PR TITLE
Export folders that have an index.tsx file

### DIFF
--- a/src/commands/ExportAll.ts
+++ b/src/commands/ExportAll.ts
@@ -33,10 +33,13 @@ export class ExportAll {
           if (includeFolders) {
             // Only allow folder which contain an index file
             if (fs.lstatSync(absPath).isDirectory()) {
-              const indexPath = path.join(absPath, '/index.ts');
-              if (fs.existsSync(indexPath)) {
-                relPath = getRelativeFolderPath(absPath);
-                include = true;
+              for (const indexFile of ['index.ts', 'index.tsx']) {
+                const indexPath = path.join(absPath, indexFile);
+                if (fs.existsSync(indexPath)) {
+                  relPath = getRelativeFolderPath(absPath);
+                  include = true;
+                  break;
+                }
               }
             }
           }


### PR DESCRIPTION
This should make it possible to export folders like this:

- /Button/index.tsx
- /Button/Icon.tsx
- /Button/style.module.scss
- /Footer.tsx
- /Header.tsx

```
export * from './Button';
export * from './Footer';
export * from './Header';
```