### PR TITLE
feature: add banner text

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,11 @@
 							"Double quote"
 						],
 						"description": "Specify the character that you want to use as the quoting character; typically ' or \""
+					},
+					"exportall.config.banner": {
+						"type": "string",
+						"default": "",
+						"description": "Specify the banner text that should be added at the top of each barrel file"
 					}
 				}
 			}

--- a/src/commands/ExportAll.ts
+++ b/src/commands/ExportAll.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { getSettingName, CONFIG_EXCLUDE, CONFIG_INCLUDE_FOLDERS, CONFIG_RELATIVE_EXCLUDE, CONFIG_SEMIS, CONFIG_QUOTE, EXTENSION_NAME } from '../constants';
+import { getSettingName, CONFIG_EXCLUDE, CONFIG_INCLUDE_FOLDERS, CONFIG_RELATIVE_EXCLUDE, CONFIG_SEMIS, CONFIG_QUOTE, EXTENSION_NAME, CONFIG_BANNER } from '../constants';
 import { getRelativeFolderPath } from '../helpers';
 import { Logger } from '../helpers/logger';
 
@@ -19,6 +19,7 @@ export class ExportAll {
       const excludeRel: string | undefined = vscode.workspace.getConfiguration().get(getSettingName(CONFIG_RELATIVE_EXCLUDE));
       const includeFolders: boolean | undefined = vscode.workspace.getConfiguration().get(getSettingName(CONFIG_INCLUDE_FOLDERS));
       const semis: boolean | undefined = vscode.workspace.getConfiguration().get(getSettingName(CONFIG_SEMIS));
+      const banner: string | undefined = vscode.workspace.getConfiguration().get(getSettingName(CONFIG_BANNER));
       const quote: "\"" | "'"  = vscode.workspace.getConfiguration().get(getSettingName(CONFIG_QUOTE)) ?? "'";
 
       const folderPath = uri.fsPath;
@@ -111,6 +112,10 @@ export class ExportAll {
 
           let fileContents = document.getText();
           let updatedFileContents = output.join("");
+
+
+          // add barrel file banner if any
+          updatedFileContents =    banner !== ""? `//${banner} \n\n${updatedFileContents}` : updatedFileContents;
 
           if (fileContents !== updatedFileContents) {
             const documentRange = new vscode.Range(

--- a/src/constants/Extension.ts
+++ b/src/constants/Extension.ts
@@ -5,6 +5,7 @@ export const CONFIG_RELATIVE_EXCLUDE = 'config.relExclusion';
 export const CONFIG_INCLUDE_FOLDERS = 'config.includeFoldersToExport';
 export const CONFIG_SEMIS = 'config.semis';
 export const CONFIG_QUOTE = 'config.quote';
+export const CONFIG_BANNER = 'config.banner';
 
 export const EXTENSION_NAME = "Barrel Generator";
 


### PR DESCRIPTION
Adds banner text if the user has set it on settings. If theres no banner text, the file content is similar to old format.

With banner: 

```ts
// THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)

export * from './application.entity';
export * from './banks.entity';
```


Without banner:

```ts
export * from './application.entity';
export * from './banks.entity';
```
Closes #16 