### PR TITLE
Added option to keep file extensions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,11 @@
 						"default": true,
 						"description": "Specify if you want to enable/disable the usage of semis in the barrel file."
 					},
+					"exportall.config.keepExtensions": {
+						"type": "boolean",
+						"default": false,
+						"description": "Whether to keep file extensions (for use with Deno/ESM)."
+					},
 					"exportall.config.quote": {
 						"type": "string",
 						"default": "'",

--- a/src/commands/ExportAll.ts
+++ b/src/commands/ExportAll.ts
@@ -40,6 +40,9 @@ export class ExportAll {
       const includeFolders: boolean | undefined = config.get(
         CONFIG_INCLUDE_FOLDERS
       );
+      const keepExtensions: boolean | undefined = config.get(
+        CONFIG_KEEP_EXTENSIONS
+      );
       const semis: boolean | undefined = config.get(CONFIG_SEMIS);
       const quote: '"' | "'" = config.get(CONFIG_QUOTE) ?? "'";
       const message: string | string[] | undefined = config.get<
@@ -124,11 +127,15 @@ export class ExportAll {
       // Check if there are still files after the filter
       if (filesToExport && filesToExport.length > 0) {
         let output = filesToExport.map((item) => {
-          const fileWithoutExtension =
-            item.type === "folder" ? item.name : path.parse(item.name).name;
-          return `export * from ${quote}./${fileWithoutExtension}${quote}${
-            semis ? ";" : ""
-          }\n`;
+          let filePath: string;
+          if (keepExtensions) {
+            filePath =
+              item.type === "folder" ? path.join(item.name, "index.ts") : item.name;
+          } else {
+            filePath =
+              item.type === "folder" ? item.name : path.parse(item.name).name;
+          }
+          return `export * from ${quote}./${filePath}${quote}${semis ? ";" : ""}\n`;
         });
 
         if (output && output.length > 0) {

--- a/src/constants/Extension.ts
+++ b/src/constants/Extension.ts
@@ -3,6 +3,7 @@ export const CONFIG_FOLDERS = 'config.folderListener';
 export const CONFIG_EXCLUDE = 'config.exclude';
 export const CONFIG_RELATIVE_EXCLUDE = 'config.relExclusion';
 export const CONFIG_INCLUDE_FOLDERS = 'config.includeFoldersToExport';
+export const CONFIG_KEEP_EXTENSIONS = 'config.keepExtensions';
 export const CONFIG_SEMIS = 'config.semis';
 export const CONFIG_QUOTE = 'config.quote';
 export const CONFIG_MESSAGE = 'config.message';


### PR DESCRIPTION
Hey, thanks for the extension! Very useful, though I was trying out Deno and it requires specifiers to include the filename extension, so I added an option `config.keepExtensions: boolean` to do just that.

One thing to note, however, is that it will do a `path.join(item.name, 'index.ts')` when it is a **folder**, which can be a problem when it is an `index.tsx`, though I was unsure how to solve that cleanly, maybe you can help here if you need this.

It solves #11 :)

Cheers!