### PR TITLE
feat: add support for named exports in barrel file and `export type`

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,11 @@
 						"default": true,
 						"description": "Specify if you want to include folder as well to the module export. Will only be applied if folder contains a `index.ts` file."
 					},
+					"exportall.config.namedExports": {
+						"type": "boolean",
+						"default": false,
+						"description": "Specify if you want to use named exports in the barrel file."
+					},
 					"exportall.config.folderListener": {
 						"type": "array",
 						"default": [],

--- a/src/commands/ExportAll.ts
+++ b/src/commands/ExportAll.ts
@@ -16,6 +16,7 @@ import {
 import {
   clearWildcard,
   getAbsoluteFolderPath,
+  getFileContents,
   getRelativeFolderPath,
   parseFileForNamedExports,
   parseWinPath,
@@ -131,15 +132,19 @@ export class ExportAll {
             item.type === "folder" ? item.name : path.parse(item.name).name;
           if (namedExports) {
             const filePath = path.join(uri.fsPath, item.name);
-            const fileContents = fs.readFileSync(filePath, 'utf8');
+            const fileContents = getFileContents(filePath);
             const { namedExports, typeExports } = parseFileForNamedExports(fileContents);
 
             const namedExportsStr = namedExports.filter(Boolean).join(', ');
-            const typeExportsStr = typeExports.filter(Boolean).map(typeExport => `type ${typeExport}`).join(', ');
-            if (!namedExportsStr && !typeExportsStr) {
-              return '';
+            const typeExportsStr = typeExports.filter(Boolean).join(', ');
+            let exportStr = '';
+            if (namedExportsStr) {
+              exportStr += `export { ${namedExportsStr} } from ${quote}./${fileWithoutExtension}${quote}${semis ? ";" : ""}\n`;
             }
-            return `export { ${namedExportsStr}${typeExportsStr ? `, ${typeExportsStr}` : ''} } from ${quote}./${fileWithoutExtension}${quote}${semis ? ";" : ""}\n`;
+            if (typeExportsStr) {
+              exportStr += `export type { ${typeExportsStr} } from ${quote}./${fileWithoutExtension}${quote}${semis ? ";" : ""}\n`;
+            }
+            return exportStr;
           } else {
             return `export * from ${quote}./${fileWithoutExtension}${quote}${semis ? ";" : ""}\n`;
           }

--- a/src/constants/Extension.ts
+++ b/src/constants/Extension.ts
@@ -6,6 +6,7 @@ export const CONFIG_INCLUDE_FOLDERS = 'config.includeFoldersToExport';
 export const CONFIG_SEMIS = 'config.semis';
 export const CONFIG_QUOTE = 'config.quote';
 export const CONFIG_MESSAGE = 'config.message';
+export const CONFIG_NAMED_EXPORTS = 'config.namedExports';
 
 export const EXTENSION_NAME = "Barrel Generator";
 

--- a/src/helpers/getFileContents.ts
+++ b/src/helpers/getFileContents.ts
@@ -1,0 +1,18 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const getFileContents = (filePath: string): string => {
+  const barrelFiles = ['index.ts', 'index.tsx'];
+  if (fs.lstatSync(filePath).isDirectory()) {
+    for (const indexFile of barrelFiles) {
+      const indexPath = path.join(filePath, indexFile);
+      if (fs.existsSync(indexPath)) {
+        return fs.readFileSync(indexPath, 'utf8');
+      }
+    }
+    return '';
+  } else if (fs.lstatSync(filePath).isFile()) {
+    return fs.readFileSync(filePath, 'utf8');
+  }
+  return '';
+};

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from "./clearWildcard";
 export * from "./logger";
+export * from "./parseFileForNamedExports";
 export * from "./parseWinPath";
 export * from "./util";

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from "./clearWildcard";
+export * from "./getFileContents";
 export * from "./logger";
 export * from "./parseFileForNamedExports";
 export * from "./parseWinPath";

--- a/src/helpers/parseFileForNamedExports.ts
+++ b/src/helpers/parseFileForNamedExports.ts
@@ -1,0 +1,39 @@
+import * as typescript from 'typescript';
+
+export const parseFileForNamedExports = (fileContents: string) => {
+    const namedExports: string[] = [];
+    const typeExports: string[] = [];
+    const sourceFile = typescript.createSourceFile(
+      'temp.ts',
+      fileContents,
+      typescript.ScriptTarget.Latest,
+      true,
+      typescript.ScriptKind.TS
+    );
+
+    const parseFile = (node: typescript.Node) => {
+        if (typescript.isExportDeclaration(node)) {
+            if (node.exportClause && typescript.isNamedExports(node.exportClause)) {
+                node.exportClause.elements.forEach(element => namedExports.push(element.name.getText()));
+            }
+            if (node.moduleSpecifier) {
+                namedExports.push(node.moduleSpecifier.getText());
+            }
+        } else if (typescript.isExportAssignment(node)) {
+            namedExports.push(node.expression.getText());
+        } else if (typescript.isExportSpecifier(node)) {
+            namedExports.push(node.name.getText());
+        } else if ((typescript.isFunctionDeclaration(node) || typescript.isClassDeclaration(node) || typescript.isInterfaceDeclaration(node)) && node.modifiers?.some(m => m.kind === typescript.SyntaxKind.ExportKeyword)) {
+            namedExports.push(node.name?.getText() || '');
+        } else if (typescript.isTypeAliasDeclaration(node) && node.modifiers?.some(m => m.kind === typescript.SyntaxKind.ExportKeyword)) {
+            typeExports.push(node.name?.getText() || '');
+        } else if (typescript.isVariableStatement(node) && node.modifiers?.some(m => m.kind === typescript.SyntaxKind.ExportKeyword)) {
+            node.declarationList.declarations.forEach(declaration => namedExports.push(declaration.name.getText()));
+        }
+        typescript.forEachChild(node, parseFile);
+    };
+
+    parseFile(sourceFile);
+
+    return { namedExports, typeExports };
+};


### PR DESCRIPTION
Adds support for named exports via config setting -- [Issue 14](https://github.com/estruyf/vscode-typescript-exportallmodules/issues/14) with `export type` for types and interfaces -- [issue 13](https://github.com/estruyf/vscode-typescript-exportallmodules/issues/13)

<img width="460" alt="image" src="https://github.com/estruyf/vscode-typescript-exportallmodules/assets/194907/19bb568d-12fb-4e81-ac66-651d64e66f72">
<img width="497" alt="image" src="https://github.com/estruyf/vscode-typescript-exportallmodules/assets/194907/e294f420-0a2a-402e-ad5d-e9691022d635">

<img width="446" alt="image" src="https://github.com/estruyf/vscode-typescript-exportallmodules/assets/194907/34b0e5b4-f358-4bce-9840-277ea4eddd8f">
