### PR TITLE
Add `index` for folder export with extension provided

### DIFF
--- a/src/commands/ExportAll.ts
+++ b/src/commands/ExportAll.ts
@@ -132,6 +132,11 @@ export class ExportAll {
               ? fileExtension
               : `.${fileExtension}`;
           }
+          if (fileExtension && item.type === "folder") {
+            fileSuffix = fileExtension.startsWith(`.`)
+              ? `/index${fileExtension}`
+              : `/index.${fileExtension}`;
+          }
 
           if (namedExports) {
             const filePath = join(uri.fsPath, item.name);


### PR DESCRIPTION
Just updated and the file extension work like a charm! But, the folder are still missing. Here a quick pull request that should do the trick.

When using an extension, the folder export must explicitly call the `index.js` file inside the folder.

```ts
// export * from "./folder"; // Wrong folder export
export * from "./folder/index.js"; // Good folder export
export * from "./file.js"; // Good file export
```